### PR TITLE
[Bug] Retrieve All Project Tasks When Calling `getTasksService` (SC-196153)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -35,6 +35,7 @@ module.exports = {
     "^.+\\.mjs$": "@swc/jest",
   },
   moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/src/$1",
     "\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
       "<rootDir>/config/jest/fileTransform.js",
     "\\.(css|less)$": "<rootDir>/config/jest/fileTransform.js",

--- a/src/components/TaskCommentForm/TaskCommentForm.tsx
+++ b/src/components/TaskCommentForm/TaskCommentForm.tsx
@@ -52,6 +52,7 @@ const TaskCommentForm: FC<Props> = ({ error, onSubmit, onCancel }) => {
       <Stack justify="space-between">
         <Button
           type="submit"
+          data-testid="submit-button"
           text="Add"
           disabled={isSubmitting || !isValid}
           loading={isSubmitting}

--- a/src/components/TaskCommentForm/__tests__/TaskForm.test.tsx
+++ b/src/components/TaskCommentForm/__tests__/TaskForm.test.tsx
@@ -1,7 +1,8 @@
-import { cleanup, waitFor } from "@testing-library/react";
+import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { render } from "../../../../testing";
 import { TaskCommentForm } from "../TaskCommentForm";
+
 
 describe("LinkTasks", () => {
   afterEach(() => {
@@ -14,13 +15,12 @@ describe("LinkTasks", () => {
       <TaskCommentForm onSubmit={jest.fn()} />
     ), { wrappers: { theme: true } });
 
-    waitFor(async () => {
-      expect(await findByText("New comment")).toBeInTheDocument();
-      expect(await findByText("Attachments")).toBeInTheDocument();
+    expect(await findByText("New comment")).toBeInTheDocument();
+    expect(await findByText("Attachments")).toBeInTheDocument();
 
-      expect(await findByText("Create")).toBeVisible();
-      expect(await findByText("Cancel")).toBeVisible();
-    });
+    const submitButton = screen.getByTestId("submit-button");
+    expect(submitButton).toBeVisible();
+    expect(await findByText("Cancel")).toBeVisible();
   });
 
   test("should should navigate to task details", async () => {

--- a/src/services/asana/getTasksService.test.ts
+++ b/src/services/asana/getTasksService.test.ts
@@ -80,4 +80,67 @@ describe('getTasksService', () => {
     expect(mockedBaseRequest).toHaveBeenCalledTimes(1)
     expect(result).toEqual({ data: tasks })
   })
+
+  it('should break the loop on repeated next_page.uri to avoid infinite loops', async () => {
+    const taskPage1: Task[] = [{ gid: '1', name: 'Task 1' } as Task]
+    const taskPage2: Task[] = [{ gid: '2', name: 'Task 2' } as Task]
+    const taskPage3: Task[] = [{ gid: '3', name: 'Task 3' } as Task]
+    const taskPage4: Task[] = [{ gid: '4', name: 'Task 4' } as Task]
+
+    mockedBaseRequest
+      .mockResolvedValueOnce({
+        data: taskPage1,
+        next_page: { uri: 'https://draft.com/next-page' } as NextPage,
+      })
+      .mockResolvedValueOnce({
+        data: taskPage2,
+        next_page: { uri: 'https://draft.com/next-page-2' } as NextPage,
+      })
+      .mockResolvedValueOnce({
+        data: taskPage3,
+        next_page: { uri: 'https://draft.com/next-page-2' } as NextPage,
+      })
+      .mockResolvedValueOnce({
+        data: taskPage4,
+        next_page: null,
+      })
+
+    const result = await getTasksService(mockClient, projectId)
+
+    expect(mockedBaseRequest).toHaveBeenCalledTimes(3)
+    expect(result).toEqual({ data: [...taskPage1, ...taskPage2, ...taskPage3] })
+  })
+
+  it('should not fetch more than the max allowed pages even if there are more pages available', async () => {
+    const taskPage1: Task[] = [{ gid: '1', name: 'Task 1' } as Task]
+    const taskPage2: Task[] = [{ gid: '2', name: 'Task 2' } as Task]
+    const taskPage3: Task[] = [{ gid: '3', name: 'Task 3' } as Task]
+    const taskPage4: Task[] = [{ gid: '4', name: 'Task 4' } as Task]
+
+    mockedBaseRequest.mockReset();
+
+    mockedBaseRequest
+      .mockResolvedValueOnce({
+        data: taskPage1,
+        next_page: { uri: 'https://draft.com/next-page/2' } as NextPage,
+      })
+      .mockResolvedValueOnce({
+        data: taskPage2,
+        next_page: { uri: 'https://draft.com/next-page/3' } as NextPage,
+      })
+      .mockResolvedValueOnce({
+        data: taskPage3,
+        next_page: { uri: 'https://draft.com/next-page/4' } as NextPage,
+      })
+      .mockResolvedValueOnce({
+        data: taskPage4,
+        next_page: null,
+      })
+
+    const result = await getTasksService(mockClient, projectId, { maxPages: 1 })
+
+    expect(mockedBaseRequest).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ data: [...taskPage1] })
+  });
+
 })

--- a/src/services/asana/getTasksService.test.ts
+++ b/src/services/asana/getTasksService.test.ts
@@ -1,0 +1,83 @@
+import { getTasksService } from './getTasksService';
+import { baseRequest } from './baseRequest';
+import type { IDeskproClient } from '@deskpro/app-sdk';
+import type { Project, Task } from './types';
+import type { NextPage } from '@/types';
+
+jest.mock('./baseRequest');
+
+const mockedBaseRequest = baseRequest as jest.MockedFunction<typeof baseRequest>;
+
+describe('getTasksService', () => {
+  const mockClient = {} as IDeskproClient;
+  const projectId = '12345' as Project["gid"];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return an empty array if no projectId is provided', async () => {
+    const result = await getTasksService(mockClient, '')
+    expect(result).toEqual({ data: [] })
+    expect(mockedBaseRequest).not.toHaveBeenCalled()
+  })
+
+  it('should successfully fetch and return tasks from a single page response', async () => {
+    const tasks: Task[] = [{ gid: '1', name: 'Draft 1' } as Task]
+
+    mockedBaseRequest.mockResolvedValueOnce({
+      data: tasks,
+      next_page: null,
+    })
+
+    const result = await getTasksService(mockClient, projectId)
+
+    expect(mockedBaseRequest).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ data: tasks })
+  })
+
+  it('should successfully fetch and return tasks across multiple pages', async () => {
+    const taskPage1: Task[] = [{ gid: '1', name: 'Task 1' } as Task]
+    const taskPage2: Task[] = [{ gid: '2', name: 'Task 2' } as Task]
+
+    mockedBaseRequest
+      .mockResolvedValueOnce({
+        data: taskPage1,
+        next_page: { uri: 'https://draft.com/next-page' } as NextPage,
+      })
+      .mockResolvedValueOnce({
+        data: taskPage2,
+        next_page: null,
+      })
+
+    const result = await getTasksService(mockClient, projectId)
+
+    expect(mockedBaseRequest).toHaveBeenCalledTimes(2)
+    expect(result).toEqual({ data: [...taskPage1, ...taskPage2] })
+  })
+
+  it('should handle empty responses', async () => {
+    mockedBaseRequest.mockResolvedValueOnce({
+      data: [],
+      next_page: null,
+    })
+
+    const result = await getTasksService(mockClient, projectId)
+
+    expect(mockedBaseRequest).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ data: [] })
+  })
+
+  it('should handle undefined next_page correctly', async () => {
+    const tasks: Task[] = [{ gid: '1', name: 'Task 1' } as Task]
+
+    mockedBaseRequest.mockResolvedValueOnce({
+      data: tasks,
+    })
+
+    const result = await getTasksService(mockClient, projectId)
+
+    expect(mockedBaseRequest).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ data: tasks })
+  })
+})

--- a/src/services/asana/getTasksService.ts
+++ b/src/services/asana/getTasksService.ts
@@ -1,24 +1,37 @@
 import { baseRequest } from "./baseRequest";
-import { TASK_FIELDS } from "../../constants";
+import { BASE_URL, TASK_FIELDS } from "@/constants";
 import type { IDeskproClient } from "@deskpro/app-sdk";
 import type { Project, Task } from "./types";
+import { NextPage } from "@/types";
 
-const getTasksService = (
-  client: IDeskproClient,
-  projectId: Project["gid"],
-) => {
+export async function getTasksService(client: IDeskproClient, projectId: Project["gid"]) {
   if (!projectId) {
-    return Promise.resolve({ data: [] });
+    return Promise.resolve({ data: [] as Task[] });
   }
 
-  return baseRequest<Task[]>(client, {
-    url: "/tasks",
-    queryParams: {
-      limit: "100",
-      project: projectId,
-      opt_fields: TASK_FIELDS.join(","),
-    },
-  });
-};
+  const allTasks: Task[] = []
 
-export { getTasksService };
+  let nextPageUrl: string | null = `${BASE_URL}/tasks?` + new URLSearchParams({
+    limit: "100",
+    project: projectId,
+    opt_fields: TASK_FIELDS.join(","),
+  }).toString()
+
+
+  while (nextPageUrl) {
+    const tasksResponse: { data: Task[], next_page?: null | NextPage } = await baseRequest<Task[]>(client, {
+      rawUrl: nextPageUrl
+    })
+
+    allTasks.push(...tasksResponse.data ?? []);
+
+
+    if (tasksResponse.next_page?.uri) {
+      nextPageUrl = tasksResponse.next_page.uri;
+    } else {
+      nextPageUrl = null;
+    }
+  }
+
+  return { data: allTasks }
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,14 +26,19 @@ export type RequestParams = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data?: any,
   headers?: Dict<string>,
-  queryParams?: string|Dict<string>|ParamKeyValuePair[],
+  queryParams?: string | Dict<string> | ParamKeyValuePair[],
   settings?: Maybe<Settings>,
 };
 
+export type NextPage = {
+  offset: string,
+  path: string,
+  uri: string
+}
 export type Request = <T>(
   client: IDeskproClient,
   params: RequestParams,
-) => Promise<{ data: T }>;
+) => Promise<{ data: T, next_page?: null | NextPage }>;
 
 /** Deskpro types */
 export type Settings = {
@@ -60,7 +65,7 @@ export type EventPayload =
   | NavigateToChangePage
   | { type: "unlink", task: Task }
   | { type: 'logOut' }
-;
+  ;
 
 export type EntityMetadata = {
   id: Task["gid"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,11 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["vite/client", "jest", "@testing-library/jest-dom", "@typescript/lib-dom"]
+    "types": ["vite/client", "jest", "@testing-library/jest-dom", "@typescript/lib-dom"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["./src"]
 }


### PR DESCRIPTION
## Description

This PR fixes a bug preventing agents from viewing some tasks when they had over 100 tasks on a project.

## Summary by Sourcery

Fix the task retrieval bug by implementing pagination in getTasksService to fetch all project tasks, update related types and configurations, and enhance testing coverage.

Bug Fixes:
- Correct getTasksService to handle projects with over 100 tasks by paginating through all pages

Enhancements:
- Extend baseRequest signature and add NextPage type to support pagination metadata
- Add data-testid attribute to TaskCommentForm submit button for more reliable testing

Build:
- Configure TypeScript baseUrl and path alias '@/' in tsconfig.json
- Add corresponding moduleNameMapper entry in jest.config.js for '@/' imports

Tests:
- Add comprehensive unit tests for getTasksService covering single-page, multi-page, empty, and undefined next_page scenarios
- Simplify TaskCommentForm tests by removing unnecessary waitFor and using screen.getByTestId for the submit button