### PR TITLE
[feature] SC-166737/improve app proxy security by restricting where token replacements can go

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -119,12 +119,25 @@
       {
         "url": "https://app.asana.com/api/1.0/.*",
         "methods": ["GET", "POST", "PUT"],
-        "timeout": 20
+        "timeout": 20,
+        "settingsInjection": {
+          "access_token": {
+            "headers": ["Authorization"]
+          }
+        }
       },
       {
         "url": "https://app.asana.com/-/.*",
         "methods": ["GET", "POST"],
-        "timeout": 20
+        "timeout": 20,
+        "settingsInjection": {
+          "client_id": {
+            "body": ["client_id"]
+          },
+          "client_secret": {
+            "body": ["client_secret"]
+          }
+        }
       }
     ]
   }

--- a/manifest.json
+++ b/manifest.json
@@ -122,7 +122,7 @@
         "timeout": 20,
         "settingsInjection": {
           "access_token": {
-            "headers": ["Authorization"]
+            "header": ["Authorization"]
           }
         }
       },


### PR DESCRIPTION
This pull request updates the API manifest configuration to support dynamic injection of authentication settings for Asana API requests. The main change is the addition of `settingsInjection` blocks, which specify how credentials should be included in API requests.

Authentication and settings injection improvements:

* Added a `settingsInjection` block to the Asana API endpoint (`https://app.asana.com/api/1.0/.*`) to inject the `access_token` into the `Authorization` header.
* Added a `settingsInjection` block to the Asana OAuth endpoint (`https://app.asana.com/-/.*`) to inject `client_id` and `client_secret` into the request body.